### PR TITLE
[Feat] create orders crud api

### DIFF
--- a/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
+++ b/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
@@ -1,0 +1,52 @@
+package com.example.likelion13th_spring.Controller;
+
+import com.example.likelion13th_spring.dto.request.*;
+import com.example.likelion13th_spring.dto.response.OrdersResponseDto;
+import com.example.likelion13th_spring.dto.response.ProductResponseDto;
+import com.example.likelion13th_spring.service.OrdersService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrdersController {
+
+    private final OrdersService ordersService;
+
+    // 주문 생성
+    @PostMapping
+    public ResponseEntity<OrdersResponseDto> createOrders(@RequestBody OrdersRequestDto dto) {
+        return ResponseEntity.ok(ordersService.createOrders(dto));
+    }
+
+    // 사용자 별 주문 조회
+    @GetMapping
+    public ResponseEntity<List<OrdersResponseDto>> getOrdersByMemberId(@RequestBody OrdersGetRequestDto dto) {
+        return ResponseEntity.ok(ordersService.getOrdersByMemberId(dto));
+    }
+
+    // 개별 주문 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<OrdersResponseDto> getOrdersById(@PathVariable Long id) {
+        return ResponseEntity.ok(ordersService.getOrdersById(id));
+    }
+
+    // 특정 주문 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<OrdersResponseDto> updateOrders(@PathVariable Long id,
+                                                            @RequestBody OrdersRequestDto.ShippingAddressRequestDto dto) {
+        return ResponseEntity.ok(ordersService.updateOrders(id, dto));
+    }
+
+    // 특정 주문 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteOrders(@PathVariable Long id,
+                                                @RequestBody OrdersDeleteRequestDto dto) {
+        ordersService.deleteOrders(id, dto);
+        return ResponseEntity.ok("주문이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
+++ b/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
@@ -44,9 +44,8 @@ public class OrdersController {
 
     // 특정 주문 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteOrders(@PathVariable Long id,
-                                                @RequestBody OrdersDeleteRequestDto dto) {
-        ordersService.deleteOrders(id, dto);
+    public ResponseEntity<String> deleteOrders(@PathVariable Long id) {
+        ordersService.deleteOrders(id);
         return ResponseEntity.ok("주문이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/likelion13th_spring/domain/Orders.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/Orders.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,5 +34,12 @@ public class Orders extends BaseTimeEntity {
 
     @OneToOne(mappedBy = "orders", cascade = CascadeType.ALL)
     private Coupon coupon;
+
+    @OneToOne(mappedBy = "orders", cascade = CascadeType.ALL)
+    private ShippingAddress shippingAddress;
+
+    public void addShippingAddress(ShippingAddress shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
 }
 

--- a/src/main/java/com/example/likelion13th_spring/domain/Product.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/Product.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity

--- a/src/main/java/com/example/likelion13th_spring/domain/ShippingAddress.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/ShippingAddress.java
@@ -1,0 +1,46 @@
+package com.example.likelion13th_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShippingAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String recipient;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String streetAddress;
+
+    @Column(nullable = false)
+    private String addressDetail;
+
+    @Column(nullable = false)
+    private String postalCode;
+
+    @OneToOne
+    @JoinColumn(name = "order_id")
+    private Orders orders;
+
+    public void update(String recipient, String phoneNumber, String streetAddress, String addressDetail, String postalCode) {
+        this.recipient = recipient;
+        this.phoneNumber = phoneNumber;
+        this.streetAddress = streetAddress;
+        this.addressDetail = addressDetail;
+        this.postalCode = postalCode;
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
@@ -1,8 +1,0 @@
-package com.example.likelion13th_spring.dto.request;
-
-import lombok.Getter;
-
-@Getter
-public class OrdersDeleteRequestDto {
-    private Long memberId;
-}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.likelion13th_spring.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrdersDeleteRequestDto {
+    private Long memberId;
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersGetRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersGetRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.likelion13th_spring.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrdersGetRequestDto {
+    private Long memberId;
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersRequestDto.java
@@ -1,0 +1,56 @@
+package com.example.likelion13th_spring.dto.request;
+
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.domain.Orders;
+import com.example.likelion13th_spring.domain.Product;
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class OrdersRequestDto {
+
+    private Long memberId;
+    private Long couponId;
+    private ShippingAddressRequestDto shippingAddress;
+    private List<ProductOrdersRequestDto> productOrders;
+
+    @Getter
+    public static class ProductOrdersRequestDto {
+        private Long productId;
+        private Integer quantity;
+
+        public ProductOrders toEntity(Orders orders, Product product) {
+            return ProductOrders.builder()
+                .orders(orders)
+                .product(product)
+                .quantity(this.quantity)
+                .build();
+        }
+    }
+
+    @Getter
+    public static class ShippingAddressRequestDto {
+
+        private String recipient;
+        private String phoneNumber;
+        private String streetAddress;
+        private String addressDetail;
+        private String postalCode;
+
+        public ShippingAddress toEntity(Orders orders) {
+            return ShippingAddress.builder()
+                .orders(orders)
+                .recipient(this.getRecipient())
+                .phoneNumber(this.getPhoneNumber())
+                .streetAddress(this.getStreetAddress())
+                .addressDetail(this.getAddressDetail())
+                .postalCode(this.getPostalCode())
+                .build();
+        }
+
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/response/OrdersResponseDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/response/OrdersResponseDto.java
@@ -1,0 +1,78 @@
+package com.example.likelion13th_spring.dto.response;
+
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.domain.Orders;
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrdersResponseDto {
+    private Long id;
+    private String deliverStatus;
+    private Long couponId;
+    private List<ProductOrdersResponseDto> productOrders;
+    private ShippingAddressResponseDto shippingAddress;
+
+    public static OrdersResponseDto fromEntity(Orders orders) {
+        return OrdersResponseDto.builder()
+            .id(orders.getId())
+            .deliverStatus(orders.getDeliverStatus().toString())
+            .couponId(orders.getCoupon() != null ? orders.getCoupon().getId() : null)
+            .productOrders(
+                orders.getProductOrders().stream()
+                    // map: 스트림의 각 요소를 다른 타입으로 변환, 각 요소에 적용할 함수 전달
+                    .map(ProductOrdersResponseDto::fromEntity)
+                    .toList()  // 스트림을 다시 리스트로 모음
+            )
+            .shippingAddress(
+                orders.getShippingAddress() != null
+                    ? ShippingAddressResponseDto.fromEntity(orders.getShippingAddress())
+                    : null
+            )
+            .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ProductOrdersResponseDto {
+        private Long productId;
+        private Integer quantity;
+
+        public static ProductOrdersResponseDto fromEntity(ProductOrders productOrders) {
+            return ProductOrdersResponseDto.builder()
+                .productId(productOrders.getProduct().getId())
+                .quantity(productOrders.getQuantity())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ShippingAddressResponseDto {
+        private String recipient;
+        private String phoneNumber;
+        private String streetAddress;
+        private String addressDetail;
+        private String postalCode;
+
+        public static ShippingAddressResponseDto fromEntity(ShippingAddress shippingAddress) {
+            return ShippingAddressResponseDto.builder()
+                .recipient(shippingAddress.getRecipient())
+                .phoneNumber(shippingAddress.getPhoneNumber())
+                .streetAddress(shippingAddress.getStreetAddress())
+                .addressDetail(shippingAddress.getAddressDetail())
+                .postalCode(shippingAddress.getPostalCode())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/CouponRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/OrdersRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/OrdersRepository.java
@@ -1,0 +1,14 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.Member;
+import com.example.likelion13th_spring.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OrdersRepository extends JpaRepository<Orders, Long>{
+    List<Orders> findAllByBuyerId(Long buyerId);
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/ShippingAddressRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/ShippingAddressRepository.java
@@ -1,0 +1,7 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShippingAddressRepository extends JpaRepository<ShippingAddress, Long> {
+}

--- a/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
@@ -1,0 +1,108 @@
+package com.example.likelion13th_spring.service;
+
+import com.example.likelion13th_spring.domain.*;
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.dto.request.*;
+import com.example.likelion13th_spring.dto.response.OrdersResponseDto;
+import com.example.likelion13th_spring.dto.response.ProductResponseDto;
+import com.example.likelion13th_spring.enums.DeliverStatus;
+import com.example.likelion13th_spring.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrdersService {
+
+    private final MemberRepository memberRepository;
+    private final CouponRepository couponRepository;
+    private final ProductRepository productRepository;
+    private final OrdersRepository ordersRepository;
+    private final ShippingAddressRepository shippingAddressRepository;
+
+    @Transactional
+    public OrdersResponseDto createOrders(OrdersRequestDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Coupon coupon;
+
+        if (dto.getCouponId() == null)
+            coupon = null;
+        else
+            coupon = couponRepository.findById(dto.getCouponId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+
+        Orders orders = Orders.builder()
+            .deliverStatus(DeliverStatus.PREPARATION)
+            .coupon(coupon)
+            .productOrders(new ArrayList<>())
+            .buyer(member)
+            .build();
+
+        ShippingAddress shippingAddress = dto.getShippingAddress().toEntity(orders);
+
+        orders.addShippingAddress(shippingAddress);
+
+        for (OrdersRequestDto.ProductOrdersRequestDto poDto : dto.getProductOrders()) {
+            Product product = productRepository.findById(poDto.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+
+            ProductOrders productOrders = poDto.toEntity(orders, product);
+
+            orders.getProductOrders().add(productOrders);
+            product.getProductOrders().add(productOrders);
+        }
+
+        ordersRepository.save(orders);
+        shippingAddressRepository.save(shippingAddress);
+
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    public List<OrdersResponseDto> getOrdersByMemberId(OrdersGetRequestDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return ordersRepository.findAllByBuyerId(member.getId()).stream()
+            .map(OrdersResponseDto::fromEntity)
+            .toList();
+    }
+
+    public OrdersResponseDto getOrdersById(Long id) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    @Transactional
+    public OrdersResponseDto updateOrders(Long id, OrdersRequestDto.ShippingAddressRequestDto dto) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        if (!orders.getDeliverStatus().equals(DeliverStatus.PREPARATION)) {
+            throw new IllegalArgumentException("배송 준비 중에만 수정할 수 있습니다.");
+        }
+
+        orders.getShippingAddress().update(dto.getRecipient(), dto.getPhoneNumber(), dto.getStreetAddress(), dto.getAddressDetail(), dto.getPostalCode());
+
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    @Transactional
+    public void deleteOrders(Long id, OrdersDeleteRequestDto dto) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        if (!orders.getDeliverStatus().equals(DeliverStatus.COMPLETED)) {
+            throw new IllegalArgumentException("배송이 완료된 경우에만 삭제할 수 있습니다.");
+        }
+
+        ordersRepository.delete(orders);
+    }
+
+}

--- a/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
@@ -94,7 +94,7 @@ public class OrdersService {
     }
 
     @Transactional
-    public void deleteOrders(Long id, OrdersDeleteRequestDto dto) {
+    public void deleteOrders(Long id) {
         Orders orders = ordersRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
 


### PR DESCRIPTION
## 개요 (Summary)
-주문 관련 CRUD api 생성

### 변경사항 (Changes)
-주문 생성, 사용자별 주문 조회, 개별 주문 조회, 주문 수정, 주문 삭제 api 구현

### 스크린샷
- 주문 생성
<img width="1843" height="978" alt="스크린샷 2025-09-21 022015" src="https://github.com/user-attachments/assets/248ffee1-ee94-4c4f-8b96-6615890270f7" />

- 사용자별 주문 조회
<img width="1705" height="961" alt="스크린샷 2025-09-21 025531" src="https://github.com/user-attachments/assets/fc8fecea-741a-4643-aab9-eb76280a2f90" />

- 개별 주문 조회
<img width="1754" height="923" alt="스크린샷 2025-09-21 030205" src="https://github.com/user-attachments/assets/efaf348d-3de8-4701-93cc-95cb98974602" />

- 주문 수정 
<img width="1694" height="871" alt="스크린샷 2025-09-21 032306" src="https://github.com/user-attachments/assets/ab037947-ad71-4427-99d9-e398f5c09669" />

- 주문 삭제
<img width="1722" height="563" alt="스크린샷 2025-09-21 032619" src="https://github.com/user-attachments/assets/e800e195-e96c-4dab-a2e2-4aebd959b181" />
