### PR TITLE
[FEAT] add spring security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
+++ b/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
@@ -1,0 +1,52 @@
+package com.example.likelion13th_spring.Controller;
+
+import com.example.likelion13th_spring.dto.request.*;
+import com.example.likelion13th_spring.dto.response.OrdersResponseDto;
+import com.example.likelion13th_spring.dto.response.ProductResponseDto;
+import com.example.likelion13th_spring.service.OrdersService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrdersController {
+
+    private final OrdersService ordersService;
+
+    // 주문 생성
+    @PostMapping
+    public ResponseEntity<OrdersResponseDto> createOrders(@RequestBody OrdersRequestDto dto) {
+        return ResponseEntity.ok(ordersService.createOrders(dto));
+    }
+
+    // 사용자 별 주문 조회
+    @GetMapping
+    public ResponseEntity<List<OrdersResponseDto>> getOrdersByMemberId(@RequestBody OrdersGetRequestDto dto) {
+        return ResponseEntity.ok(ordersService.getOrdersByMemberId(dto));
+    }
+
+    // 개별 주문 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<OrdersResponseDto> getOrdersById(@PathVariable Long id) {
+        return ResponseEntity.ok(ordersService.getOrdersById(id));
+    }
+
+    // 특정 주문 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<OrdersResponseDto> updateOrders(@PathVariable Long id,
+                                                            @RequestBody OrdersRequestDto.ShippingAddressRequestDto dto) {
+        return ResponseEntity.ok(ordersService.updateOrders(id, dto));
+    }
+
+    // 특정 주문 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteOrders(@PathVariable Long id,
+                                                @RequestBody OrdersDeleteRequestDto dto) {
+        ordersService.deleteOrders(id, dto);
+        return ResponseEntity.ok("주문이 성공적으로 삭제되었습니다.");
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
+++ b/src/main/java/com/example/likelion13th_spring/Controller/OrdersController.java
@@ -44,9 +44,8 @@ public class OrdersController {
 
     // 특정 주문 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<String> deleteOrders(@PathVariable Long id,
-                                                @RequestBody OrdersDeleteRequestDto dto) {
-        ordersService.deleteOrders(id, dto);
+    public ResponseEntity<String> deleteOrders(@PathVariable Long id) {
+        ordersService.deleteOrders(id);
         return ResponseEntity.ok("주문이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/example/likelion13th_spring/config/SecurityConfig.java
+++ b/src/main/java/com/example/likelion13th_spring/config/SecurityConfig.java
@@ -1,0 +1,62 @@
+package com.example.likelion13th_spring.config;
+
+import com.example.likelion13th_spring.service.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .cors((SecurityConfig::corsAllow)) // cors 설정
+            .csrf(AbstractHttpConfigurer::disable) // 비활성화
+            .authorizeHttpRequests((auth) -> auth
+                .requestMatchers("/join", "/login").permitAll() // 회원가입, 로그인은 모두 허용
+                .requestMatchers("/**").authenticated()) // 나머진 인증 필요
+            .formLogin(Customizer.withDefaults()) // 현재 코드에선 작동 X. name이 아니라 username이어야 함
+            .logout(Customizer.withDefaults())
+            .userDetailsService(customUserDetailsService)
+        ;
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    public static void corsAllow(CorsConfigurer<HttpSecurity> corsConfigurer) {
+        corsConfigurer.configurationSource(request -> {
+            CorsConfiguration configuration = new CorsConfiguration();
+
+            configuration.setAllowedMethods(Collections.singletonList("*"));
+            configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000")); // 프론트에서 오는 요청 허용
+            configuration.setAllowedHeaders(Collections.singletonList("*")); // 모든 헤더 허용
+            configuration.setAllowCredentials(true);
+            configuration.setMaxAge(3600L); // 1시간(3600초) 동안 오는 요청이 처리됨
+
+            return configuration;
+
+        });
+    }
+
+}

--- a/src/main/java/com/example/likelion13th_spring/controller/JoinController.java
+++ b/src/main/java/com/example/likelion13th_spring/controller/JoinController.java
@@ -1,0 +1,20 @@
+package com.example.likelion13th_spring.controller;
+
+import com.example.likelion13th_spring.dto.request.JoinRequestDto;
+import com.example.likelion13th_spring.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class JoinController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/join")
+    public void join(@RequestBody JoinRequestDto joinRequestDto) {
+        memberService.join(joinRequestDto);
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/controller/OrdersController.java
+++ b/src/main/java/com/example/likelion13th_spring/controller/OrdersController.java
@@ -1,8 +1,7 @@
-package com.example.likelion13th_spring.Controller;
+package com.example.likelion13th_spring.controller;
 
 import com.example.likelion13th_spring.dto.request.*;
 import com.example.likelion13th_spring.dto.response.OrdersResponseDto;
-import com.example.likelion13th_spring.dto.response.ProductResponseDto;
 import com.example.likelion13th_spring.service.OrdersService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/example/likelion13th_spring/controller/ProductController.java
+++ b/src/main/java/com/example/likelion13th_spring/controller/ProductController.java
@@ -1,4 +1,4 @@
-package com.example.likelion13th_spring.Controller;
+package com.example.likelion13th_spring.controller;
 
 import com.example.likelion13th_spring.dto.request.ProductDeleteRequestDto;
 import com.example.likelion13th_spring.dto.request.ProductRequestDto;

--- a/src/main/java/com/example/likelion13th_spring/domain/Member.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/Member.java
@@ -20,6 +20,7 @@ public class Member {
     private Long id;
 
     private String name;
+    private String password;
     private String address;
     private String email;
     private String phoneNumber;
@@ -44,9 +45,10 @@ public class Member {
     }
 
     @Builder
-    public Member(String name, String address, String email, String phoneNumber,
+    public Member(String name, String password, String address, String email, String phoneNumber,
                   Role role, Boolean isAdmin, Integer deposit, Integer age) {
         this.name = name;
+        this.password = password;
         this.address = address;
         this.email = email;
         this.phoneNumber = phoneNumber;

--- a/src/main/java/com/example/likelion13th_spring/domain/Orders.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/Orders.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,5 +34,12 @@ public class Orders extends BaseTimeEntity {
 
     @OneToOne(mappedBy = "orders", cascade = CascadeType.ALL)
     private Coupon coupon;
+
+    @OneToOne(mappedBy = "orders", cascade = CascadeType.ALL)
+    private ShippingAddress shippingAddress;
+
+    public void addShippingAddress(ShippingAddress shippingAddress) {
+        this.shippingAddress = shippingAddress;
+    }
 }
 

--- a/src/main/java/com/example/likelion13th_spring/domain/Product.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/Product.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity

--- a/src/main/java/com/example/likelion13th_spring/domain/ShippingAddress.java
+++ b/src/main/java/com/example/likelion13th_spring/domain/ShippingAddress.java
@@ -1,0 +1,46 @@
+package com.example.likelion13th_spring.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShippingAddress {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String recipient;
+
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    @Column(nullable = false)
+    private String streetAddress;
+
+    @Column(nullable = false)
+    private String addressDetail;
+
+    @Column(nullable = false)
+    private String postalCode;
+
+    @OneToOne
+    @JoinColumn(name = "order_id")
+    private Orders orders;
+
+    public void update(String recipient, String phoneNumber, String streetAddress, String addressDetail, String postalCode) {
+        this.recipient = recipient;
+        this.phoneNumber = phoneNumber;
+        this.streetAddress = streetAddress;
+        this.addressDetail = addressDetail;
+        this.postalCode = postalCode;
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/JoinRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/JoinRequestDto.java
@@ -1,0 +1,18 @@
+package com.example.likelion13th_spring.dto.request;
+
+import com.example.likelion13th_spring.domain.Member;
+import lombok.Getter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Getter
+public class JoinRequestDto {
+    private String name;
+    private String password;
+
+    public Member toEntity(BCryptPasswordEncoder bCryptPasswordEncoder) {
+        return Member.builder()
+            .name(this.name)
+            .password(bCryptPasswordEncoder.encode(this.password))
+            .build();
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
@@ -1,8 +1,0 @@
-package com.example.likelion13th_spring.dto.request;
-
-import lombok.Getter;
-
-@Getter
-public class OrdersDeleteRequestDto {
-    private Long memberId;
-}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersDeleteRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.likelion13th_spring.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrdersDeleteRequestDto {
+    private Long memberId;
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersGetRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersGetRequestDto.java
@@ -1,0 +1,8 @@
+package com.example.likelion13th_spring.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class OrdersGetRequestDto {
+    private Long memberId;
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/request/OrdersRequestDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/request/OrdersRequestDto.java
@@ -1,0 +1,56 @@
+package com.example.likelion13th_spring.dto.request;
+
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.domain.Orders;
+import com.example.likelion13th_spring.domain.Product;
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+public class OrdersRequestDto {
+
+    private Long memberId;
+    private Long couponId;
+    private ShippingAddressRequestDto shippingAddress;
+    private List<ProductOrdersRequestDto> productOrders;
+
+    @Getter
+    public static class ProductOrdersRequestDto {
+        private Long productId;
+        private Integer quantity;
+
+        public ProductOrders toEntity(Orders orders, Product product) {
+            return ProductOrders.builder()
+                .orders(orders)
+                .product(product)
+                .quantity(this.quantity)
+                .build();
+        }
+    }
+
+    @Getter
+    public static class ShippingAddressRequestDto {
+
+        private String recipient;
+        private String phoneNumber;
+        private String streetAddress;
+        private String addressDetail;
+        private String postalCode;
+
+        public ShippingAddress toEntity(Orders orders) {
+            return ShippingAddress.builder()
+                .orders(orders)
+                .recipient(this.getRecipient())
+                .phoneNumber(this.getPhoneNumber())
+                .streetAddress(this.getStreetAddress())
+                .addressDetail(this.getAddressDetail())
+                .postalCode(this.getPostalCode())
+                .build();
+        }
+
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/dto/response/OrdersResponseDto.java
+++ b/src/main/java/com/example/likelion13th_spring/dto/response/OrdersResponseDto.java
@@ -1,0 +1,78 @@
+package com.example.likelion13th_spring.dto.response;
+
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.domain.Orders;
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrdersResponseDto {
+    private Long id;
+    private String deliverStatus;
+    private Long couponId;
+    private List<ProductOrdersResponseDto> productOrders;
+    private ShippingAddressResponseDto shippingAddress;
+
+    public static OrdersResponseDto fromEntity(Orders orders) {
+        return OrdersResponseDto.builder()
+            .id(orders.getId())
+            .deliverStatus(orders.getDeliverStatus().toString())
+            .couponId(orders.getCoupon() != null ? orders.getCoupon().getId() : null)
+            .productOrders(
+                orders.getProductOrders().stream()
+                    // map: 스트림의 각 요소를 다른 타입으로 변환, 각 요소에 적용할 함수 전달
+                    .map(ProductOrdersResponseDto::fromEntity)
+                    .toList()  // 스트림을 다시 리스트로 모음
+            )
+            .shippingAddress(
+                orders.getShippingAddress() != null
+                    ? ShippingAddressResponseDto.fromEntity(orders.getShippingAddress())
+                    : null
+            )
+            .build();
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ProductOrdersResponseDto {
+        private Long productId;
+        private Integer quantity;
+
+        public static ProductOrdersResponseDto fromEntity(ProductOrders productOrders) {
+            return ProductOrdersResponseDto.builder()
+                .productId(productOrders.getProduct().getId())
+                .quantity(productOrders.getQuantity())
+                .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class ShippingAddressResponseDto {
+        private String recipient;
+        private String phoneNumber;
+        private String streetAddress;
+        private String addressDetail;
+        private String postalCode;
+
+        public static ShippingAddressResponseDto fromEntity(ShippingAddress shippingAddress) {
+            return ShippingAddressResponseDto.builder()
+                .recipient(shippingAddress.getRecipient())
+                .phoneNumber(shippingAddress.getPhoneNumber())
+                .streetAddress(shippingAddress.getStreetAddress())
+                .addressDetail(shippingAddress.getAddressDetail())
+                .postalCode(shippingAddress.getPostalCode())
+                .build();
+        }
+    }
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/CouponRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/CouponRepository.java
@@ -1,0 +1,7 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.Coupon;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/MemberRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/MemberRepository.java
@@ -19,4 +19,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Page<Member> findByAgeGreaterThanEqualOrderByName(Integer age, Pageable pageable);
     List<Member> findByNameStartingWith(String prefix);
+
+    boolean existsByName(String name);
 }

--- a/src/main/java/com/example/likelion13th_spring/repository/OrdersRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/OrdersRepository.java
@@ -1,0 +1,14 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.Member;
+import com.example.likelion13th_spring.domain.Orders;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface OrdersRepository extends JpaRepository<Orders, Long>{
+    List<Orders> findAllByBuyerId(Long buyerId);
+}

--- a/src/main/java/com/example/likelion13th_spring/repository/ShippingAddressRepository.java
+++ b/src/main/java/com/example/likelion13th_spring/repository/ShippingAddressRepository.java
@@ -1,0 +1,7 @@
+package com.example.likelion13th_spring.repository;
+
+import com.example.likelion13th_spring.domain.ShippingAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShippingAddressRepository extends JpaRepository<ShippingAddress, Long> {
+}

--- a/src/main/java/com/example/likelion13th_spring/service/CustomUserDetailsService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.example.likelion13th_spring.service;
+
+import com.example.likelion13th_spring.domain.Member;
+import com.example.likelion13th_spring.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String name) throws UsernameNotFoundException {
+        Member member = memberRepository.findByName(name)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return new User(member.getName(), member.getPassword(), new ArrayList<>());
+    }
+
+}

--- a/src/main/java/com/example/likelion13th_spring/service/MemberService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/MemberService.java
@@ -1,12 +1,14 @@
 package com.example.likelion13th_spring.service;
 
 import com.example.likelion13th_spring.domain.Member;
+import com.example.likelion13th_spring.dto.request.JoinRequestDto;
 import com.example.likelion13th_spring.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -16,7 +18,16 @@ import java.util.List;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    public void join(JoinRequestDto joinRequestDto) {
+        if (memberRepository.existsByName(joinRequestDto.getName()))
+            throw new IllegalArgumentException("이미 존재하는 사용자 이름입니다.");
 
+        Member member = joinRequestDto.toEntity(bCryptPasswordEncoder);
+
+        // 유저 정보 저장
+        memberRepository.save(member);
+    }
     public Page<Member> getMembersByPage(int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by("name").ascending());
         return memberRepository.findAll(pageable);

--- a/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
@@ -1,0 +1,108 @@
+package com.example.likelion13th_spring.service;
+
+import com.example.likelion13th_spring.domain.*;
+import com.example.likelion13th_spring.domain.Mapping.ProductOrders;
+import com.example.likelion13th_spring.dto.request.*;
+import com.example.likelion13th_spring.dto.response.OrdersResponseDto;
+import com.example.likelion13th_spring.dto.response.ProductResponseDto;
+import com.example.likelion13th_spring.enums.DeliverStatus;
+import com.example.likelion13th_spring.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OrdersService {
+
+    private final MemberRepository memberRepository;
+    private final CouponRepository couponRepository;
+    private final ProductRepository productRepository;
+    private final OrdersRepository ordersRepository;
+    private final ShippingAddressRepository shippingAddressRepository;
+
+    @Transactional
+    public OrdersResponseDto createOrders(OrdersRequestDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Coupon coupon;
+
+        if (dto.getCouponId() == null)
+            coupon = null;
+        else
+            coupon = couponRepository.findById(dto.getCouponId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 쿠폰입니다."));
+
+        Orders orders = Orders.builder()
+            .deliverStatus(DeliverStatus.PREPARATION)
+            .coupon(coupon)
+            .productOrders(new ArrayList<>())
+            .buyer(member)
+            .build();
+
+        ShippingAddress shippingAddress = dto.getShippingAddress().toEntity(orders);
+
+        orders.addShippingAddress(shippingAddress);
+
+        for (OrdersRequestDto.ProductOrdersRequestDto poDto : dto.getProductOrders()) {
+            Product product = productRepository.findById(poDto.getProductId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+
+            ProductOrders productOrders = poDto.toEntity(orders, product);
+
+            orders.getProductOrders().add(productOrders);
+            product.getProductOrders().add(productOrders);
+        }
+
+        ordersRepository.save(orders);
+        shippingAddressRepository.save(shippingAddress);
+
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    public List<OrdersResponseDto> getOrdersByMemberId(OrdersGetRequestDto dto) {
+        Member member = memberRepository.findById(dto.getMemberId())
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        return ordersRepository.findAllByBuyerId(member.getId()).stream()
+            .map(OrdersResponseDto::fromEntity)
+            .toList();
+    }
+
+    public OrdersResponseDto getOrdersById(Long id) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    @Transactional
+    public OrdersResponseDto updateOrders(Long id, OrdersRequestDto.ShippingAddressRequestDto dto) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        if (!orders.getDeliverStatus().equals(DeliverStatus.PREPARATION)) {
+            throw new IllegalArgumentException("배송 준비 중에만 수정할 수 있습니다.");
+        }
+
+        orders.getShippingAddress().update(dto.getRecipient(), dto.getPhoneNumber(), dto.getStreetAddress(), dto.getAddressDetail(), dto.getPostalCode());
+
+        return OrdersResponseDto.fromEntity(orders);
+    }
+
+    @Transactional
+    public void deleteOrders(Long id, OrdersDeleteRequestDto dto) {
+        Orders orders = ordersRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
+
+        if (!orders.getDeliverStatus().equals(DeliverStatus.COMPLETED)) {
+            throw new IllegalArgumentException("배송이 완료된 경우에만 삭제할 수 있습니다.");
+        }
+
+        ordersRepository.delete(orders);
+    }
+
+}

--- a/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
+++ b/src/main/java/com/example/likelion13th_spring/service/OrdersService.java
@@ -94,7 +94,7 @@ public class OrdersService {
     }
 
     @Transactional
-    public void deleteOrders(Long id, OrdersDeleteRequestDto dto) {
+    public void deleteOrders(Long id) {
         Orders orders = ordersRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("주문이 존재하지 않습니다."));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       path: /h2-console # H2 콘솔의 접근 경로
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     properties:
       hibernate:
         format_sql: true # 얘는 실제 디비로 나가는 sql을 보여줍니다


### PR DESCRIPTION
## 개요 (Summary)
-spring security를 이용해 회원가입 구현

### 변경사항 (Changes)
-securityConfig 생성, 비밀번호 암호화, 회원가입 로직, URL 수준 접근 제어 구현

### 스크린샷
- 회원가입 성공
<img width="1752" height="687" alt="image" src="https://github.com/user-attachments/assets/9c422ed1-370f-47cb-a5bb-229fe0e9df42" />

- 중복된 이름일 때
(인가 설정 주석처리)
<img width="1705" height="747" alt="image" src="https://github.com/user-attachments/assets/aeb452c0-0a35-435d-a594-75069d139596" />
<img width="1706" height="114" alt="image" src="https://github.com/user-attachments/assets/b585b359-c9b4-4cb1-aa4f-8142e76335f8" />
